### PR TITLE
Omit is default-implemented

### DIFF
--- a/api/response.ts
+++ b/api/response.ts
@@ -1,4 +1,3 @@
-import { Omit } from "../utils.ts";
 import {
   CommitId,
   Line,

--- a/utils.ts
+++ b/utils.ts
@@ -1,2 +1,0 @@
-// utilities
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;


### PR DESCRIPTION
`Omit<>`はTypeScriptの組み込み型として定義されていたので、user定義する必要がなかった