### PR TITLE
Type definitions for imports and exports

### DIFF
--- a/api/response.ts
+++ b/api/response.ts
@@ -131,7 +131,7 @@ export interface SearchedTitle {
 }
 
 /** exportもしくはbackupをとったときのページデータ */
-export interface ExportPage<hasMetadata extends true | false = false> {
+export interface ExportedPage<hasMetadata extends true | false = false> {
   /** page's title */ title: string;
   /** ページの最終更新日時 (UNIX時刻) */ updated: number;
   /** ページの最終作成日時 (UNIX時刻) */ created: number;
@@ -145,11 +145,11 @@ export interface ExportPage<hasMetadata extends true | false = false> {
     : string[];
 }
 
-export interface ExportData<hasMetadata extends true | false = false> {
+export interface ExportedData<hasMetadata extends true | false = false> {
   /** project's name */ name: string;
   /** project's display name */ displayName: string;
   /** このデータを生成した日時 (UNIX時刻) */ exported: number;
-  /** exported pages */ pages: ExportPage<hasMetadata>[];
+  /** exported pages */ pages: ExportedPage<hasMetadata>[];
 }
 
 /** メタデータ無しインポート用ページデータ */

--- a/api/response.ts
+++ b/api/response.ts
@@ -144,9 +144,48 @@ export interface ExportPage<hasMetadata extends true | false = false> {
   lines: hasMetadata extends true ? Omit<Line, "id" | "userId">[]
     : string[];
 }
+
 export interface ExportData<hasMetadata extends true | false = false> {
   /** project's name */ name: string;
   /** project's display name */ displayName: string;
   /** このデータを生成した日時 (UNIX時刻) */ exported: number;
   /** exported pages */ pages: ExportPage<hasMetadata>[];
+}
+
+/** メタデータ無しインポート用ページデータ */
+export interface ImportedLightPage {
+  /** page's title
+   *
+   * `title` should be equal to `lines[0]`
+   */
+  title: string;
+  /** page's text
+   *
+   * `lines[0]` should be equal to `title`
+   */
+  lines: string[];
+}
+/** インポート用メタデータ付き行データ */
+export interface ImportedLine {
+  /** line text */ text: string;
+  /** 行の最終更新日時 (UNIX時刻) */ updated?: number;
+  /** 行の最終作成日時 (UNIX時刻) */ created?: number;
+}
+/** メタデータ付きインポート用ページデータ */
+export interface ImportedPage {
+  /** page's title
+   *
+   * `title` should be equal to `lines[0].text`
+   */
+  title: string;
+  /** page's line data
+   *
+   * `lines[0].text` should be equal to `title`
+   */
+  lines: ImportedLine[];
+}
+/** JSON data for importing by https://scrapbox.io/api/page-data/import/:projectname.json  */
+export interface ImportedData<hasMetadata extends true | false = false> {
+  /** pages importing to a project */
+  pages: hasMetadata extends true ? ImportedPage[] : ImportedLightPage;
 }

--- a/api/response.ts
+++ b/api/response.ts
@@ -130,27 +130,23 @@ export interface SearchedTitle {
   /** ページ内のリンク */ links: string[];
 }
 
-export interface ProjectBackup {
-  name: string;
-  displayName: string;
-  exported: number;
-  pages: {
-    id: PageId;
-    title: string;
-    created: number;
-    updated: number;
-    lines: string[];
-  };
+/** exportもしくはbackupをとったときのページデータ */
+export interface ExportPage<hasMetadata extends true | false = false> {
+  /** page's title */ title: string;
+  /** ページの最終更新日時 (UNIX時刻) */ updated: number;
+  /** ページの最終作成日時 (UNIX時刻) */ created: number;
+  /** page ID */ id: string;
+  /** ページ本文
+   *
+   * `hasMetadata === true`のときは行のmetadataが入る
+   * それ以外の場合は行のテキストが入る
+   */
+  lines: hasMetadata extends true ? Omit<Line, "id" | "userId">[]
+    : string[];
 }
-export interface ProjectBackupWithMetadata {
-  name: string;
-  displayName: string;
-  exported: number;
-  pages: {
-    id: PageId;
-    title: string;
-    created: number;
-    updated: number;
-    lines: Omit<Line, "id" | "userId">[];
-  };
+export interface ExportData<hasMetadata extends true | false = false> {
+  /** project's name */ name: string;
+  /** project's display name */ displayName: string;
+  /** このデータを生成した日時 (UNIX時刻) */ exported: number;
+  /** exported pages */ pages: ExportPage<hasMetadata>[];
 }


### PR DESCRIPTION
- Export用型定義に破壊的変更を加えた
  - 名称をbackupからexportに変更
  - metadataを加えるかどうかをtype parametersで指定する
- Import用型定義を追加した