### PR TITLE
:sparkles: Implement types related to /api/commits/:projectname/:pageid

### DIFF
--- a/change.ts
+++ b/change.ts
@@ -1,0 +1,96 @@
+import { BasePage, LineId, StringLc } from "./base.ts";
+
+/** ページの変更内容 */
+export type Change =
+  | InsertChange
+  | UpdateChange
+  | DeleteChange
+  | LinksChange
+  | DescriptionsChange
+  | ImageChange
+  | TitleChange
+  | PinChange;
+
+/** 行を新規作成する変更 */
+export interface InsertChange {
+  /** このIDが示す行の上に挿入する
+   *
+   * 末尾に挿入するときは`"_end"`を指定する
+   */
+  _insert: LineId;
+
+  /** 挿入する行のデータ */
+  lines: NewLine;
+}
+
+export interface NewLine {
+  /** 新しく挿入する行のID */
+  id: LineId;
+
+  /** 行のテキスト */
+  text: string;
+}
+
+/** 既存の行を書き換える変更 */
+export interface UpdateChange {
+  /** 書き換える行のID */
+  _update: LineId;
+
+  /** 行の変更内容 */
+  lines: ChangeLine;
+}
+
+export interface ChangeLine {
+  /**変更前の文字列*/
+  origText: string;
+
+  /**変更後の文字列*/
+  text: string;
+}
+
+/** 既存の行を削除する変更 */
+export interface DeleteChange {
+  /** 削除する行のID */
+  _delete: LineId;
+
+  /** 常に `-1` */
+  lines: -1;
+}
+
+/** ページ中のリンクが変更されると発生する */
+export interface LinksChange {
+  /** 新しいリンク */
+  links: string[];
+
+  /** 新しいリンク */
+  linksLc: StringLc[];
+}
+
+/** ページのサムネイル本文が変更されると発生する */
+export interface DescriptionsChange {
+  /** 新しいサムネイル本文 */
+  descriptions: string[];
+}
+
+/** ページのサムネイルが変更されると発生する */
+export interface ImageChange {
+  /** 新しいサムネイルのURL
+   *
+   * サムネイルがなくなったときは`null`になる
+   */
+  image: string | null;
+}
+
+/** ページのタイトルが変更されると発生する */
+export interface TitleChange {
+  /** 新しいタイトル */
+  title: string;
+
+  /** 新しいタイトル */
+  titleLc: StringLc;
+}
+
+/** ページのピンの状態が変更されると発生する */
+export interface PinChange {
+  pin: BasePage["pin"];
+}

--- a/commit.ts
+++ b/commit.ts
@@ -1,0 +1,27 @@
+import { CommitId, PageId, UnixTime, UserId } from "./base.ts";
+import { Change } from "./change.ts";
+
+/** Scrapboxのページの編集commit */
+export interface Commit {
+  id: CommitId;
+
+  /** 一つ前のcommitのID
+   *
+   * 存在しないときは`null`になる
+   */
+  parentId: CommitId | null;
+
+  pageId: PageId;
+
+  /** commitの作成者 */
+  userId: UserId;
+
+  /** commitの作成日時 */
+  created: UnixTime;
+
+  /** 変更内容 */
+  changes: Change[];
+
+  /** 詳細不明 */
+  kind: "page";
+}

--- a/response.ts
+++ b/response.ts
@@ -7,6 +7,7 @@ import {
   UnixTime,
   UserId,
 } from "./base.ts";
+import { Commit } from "./commit.ts";
 
 /** 関連ページのメタデータ */
 export interface RelatedPage extends BasePage {
@@ -253,4 +254,10 @@ export interface SearchQuery {
   words: string[];
   /** NOT検索に使う語句 */
   excludes: string[];
+}
+
+/** the response type of /api/commits/:projectname/:pageid */
+export interface CommitsResponse {
+  /** 指定したページのcommits */
+  commits: Commit[];
 }

--- a/rest.ts
+++ b/rest.ts
@@ -1,5 +1,7 @@
 /** @module types used at REST API */
 
 export * from "./base.ts";
+export * from "./commit.ts";
+export * from "./change.ts";
 export * from "./response.ts";
 export * from "./error.ts";


### PR DESCRIPTION
see [📝型定義修正 (scrapbox-jp/types)](https://scrapbox.io/takker/📝型定義修正_(scrapbox-jp%2Ftypes))