### PR TITLE
:sparkles: `NotLoggedInError.details`に`project`を生やした

### DIFF
--- a/error.ts
+++ b/error.ts
@@ -25,8 +25,12 @@ export interface NotPrivilegeError extends ErrorLike {
 /** Loginが必要なAPIをloginせずに叩いたときに発生するエラー */
 export interface NotLoggedInError extends ErrorLike {
   name: "NotLoggedInError";
+
   /** 詳細情報 */
   details: {
+    /** 取得しようとしたprojectの名前 */
+    project: string;
+
     /** 使用できるログイン方法 */
     loginStrategies: (
       | "google"


### PR DESCRIPTION
see [📝型定義修正 (scrapbox-jp/types)](https://scrapbox.io/takker/📝型定義修正_(scrapbox-jp%2Ftypes))