### PR TITLE
:bug: `Item.onClick`に渡されるeventの型が違っていた

### DIFF
--- a/pageMenu.ts
+++ b/pageMenu.ts
@@ -17,7 +17,7 @@ export type Item = {
   /** the URL of an image which views on the left of the title */
   image?: string;
   /** the event listener which is executed when the menu item is clicked */
-  onClick: (event: React.MouseEvent<HTMLImageElement>) => void;
+  onClick: (event: React.MouseEvent<HTMLAnchorElement>) => void;
 };
 
 export declare class PageMenu extends BaseStore {


### PR DESCRIPTION
see [📝型定義修正 (scrapbox-jp/types)](https://scrapbox.io/takker/📝型定義修正_(scrapbox-jp%2Ftypes))