### PR TITLE
:+1: Use a derived class at listener arguments

### DIFF
--- a/baseStore.ts
+++ b/baseStore.ts
@@ -1,12 +1,17 @@
-export type BaseStoreListenerInit = { store: BaseStore; event: string };
-export type BaseStoreListener = (init: BaseStoreListenerInit) => void;
+export type BaseStoreListenerInit<Derived extends BaseStore> = {
+  store: Derived;
+  event: string;
+};
+export type BaseStoreListener<Derived extends BaseStore> = (
+  init: BaseStoreListenerInit<Derived>,
+) => void;
 export declare class BaseStore {
   constructor();
 
-  public addChangeListener(listener: BaseStoreListener): void;
-  public removeChangeListener(listener: BaseStoreListener): void;
+  public addChangeListener(listener: BaseStoreListener<this>): void;
+  public removeChangeListener(listener: BaseStoreListener<this>): void;
   public emitChange(event: string): void;
   public get listenersCount(): number;
 
-  private _onChangeListeners: BaseStoreListener[];
+  private _onChangeListeners: BaseStoreListener<this>[];
 }


### PR DESCRIPTION
close [⬜ScrapboxのBaseStoreで継承先classを使えるよう型定義を変える](https://scrapbox.io/takker/⬜ScrapboxのBaseStoreで継承先classを使えるよう型定義を変える)