### PR TITLE
fix(twitter): Adjust `TweetInfo` to the leatest type

### DIFF
--- a/response.ts
+++ b/response.ts
@@ -303,9 +303,6 @@ export interface TweetInfo {
   /** Tweet本文 */
   description: string;
 
-  /** Tweet投稿者のuser name*/
-  userName: string;
-
   /** Tweet投稿者の表示名 */
   screenName: string;
 


### PR DESCRIPTION
close [✅️api/embed-text/twitterの型定義修正](https://scrapbox.io/takker/✅️api%2Fembed-text%2Ftwitterの型定義修正)