### PR TITLE
fix(twitter): `description` may be optional

### DIFF
--- a/response.ts
+++ b/response.ts
@@ -301,7 +301,7 @@ export interface ImportedData<hasMetadata extends true | false = false> {
 /** the response type of /api/embed-text/twitter */
 export interface TweetInfo {
   /** Tweet本文 */
-  description: string;
+  description?: string;
 
   /** Tweet投稿者の表示名 */
   screenName: string;


### PR DESCRIPTION
fix #46 
see [✅️api/embed-text/twitterの型定義修正](https://scrapbox.io/takker/✅️api%2Fembed-text%2Ftwitterの型定義修正)