### PR TITLE
feat: export `scrapox` and `cosense`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,17 @@
 name: ci
 
-env:
-  DENO_VERSION: 1.x
-
 on: [push, pull_request]
+
+env:
+  DENO_VERSION: 2.x
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - name: Install Deno
-        uses: denoland/setup-deno@v1
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
         with:
           deno-version: ${{ env.DENO_VERSION }}
-      - name: Check fmt & lint & type check & test
-        run: deno task check:dry
+      - name: Check all
+        run: deno task check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,12 +7,11 @@ env:
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
 permissions:
   contents: read
   id-token: write # The OIDC ID token is used for authentication with JSR.
-
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@
 name: publish
 
 env:
-  DENO_VERSION: 1.x
+  DENO_VERSION: 2.x
 
 on:
   push:
@@ -11,16 +11,15 @@ on:
 
 permissions:
   contents: read
-  id-token: write # The OIDC ID token is used for authentication with JSR.
+  id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Deno
-        uses: denoland/setup-deno@v1
+      - uses: denoland/setup-deno@v2
         with:
           deno-version: ${{ env.DENO_VERSION }}
       - name: Publish on tag
-        run: deno task publish
+        run: deno run --allow-env --allow-run=deno --allow-read --allow-write=deno.jsonc jsr:@david/publish-on-tag@0.1.4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+docs/
+coverage/

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -2,10 +2,10 @@
   "name": "@cosense/types",
   "version": "0.0.0",
   "tasks": {
-    "check:dry": "deno fmt --check && deno lint && deno check --remote **/*.ts && deno test --parallel",
-    "check": "deno fmt && deno lint && deno check --remote **/*.ts && deno test --parallel",
-    "check:publish": "deno task check && deno publish --dry-run --allow-dirty",
-    "publish": "deno run --allow-env --allow-run=deno --allow-read --allow-write=deno.jsonc jsr:@david/publish-on-tag@0.1.x"
+    "fix": "deno fmt && deno lint --fix && deno test --allow-read --doc --parallel --shuffle && deno publish --dry-run --allow-dirty",
+    "check": "deno fmt --check && deno lint && deno test --allow-read --doc --parallel --shuffle && deno publish --dry-run",
+    "coverage": "deno test --allow-read=./ --parallel --shuffle --coverage && deno coverage --html",
+    "doc": "deno doc --html rest.ts userscript.ts"
   },
   "imports": {
     "@std/testing/types": "jsr:@std/testing@0/types"
@@ -20,5 +20,9 @@
       "dom.iterable",
       "esnext"
     ]
-  }
+  },
+  "exclude": [
+    "coverage/",
+    "docs/"
+  ]
 }

--- a/userscript.ts
+++ b/userscript.ts
@@ -10,3 +10,19 @@ export * from "./pageMenu.ts";
 export * from "./eventName.ts";
 export * from "./scrapbox.ts";
 export type { EventEmitter } from "./vendor/events.ts";
+import type { Scrapbox } from "./scrapbox.ts";
+
+// The following assignments are a workaround for esbuild
+// Use IIFE to tree-shaking
+
+/** `scrapbox` */
+export const scrapbox: Scrapbox = /* @__PURE__ */ (
+  // deno-lint-ignore no-explicit-any
+  () => (globalThis as any).scrapbox
+)();
+
+/** an alias for {@linkcode scrapbox} */
+export const cosense: Scrapbox = /* @__PURE__ */ (
+  // deno-lint-ignore no-explicit-any
+  () => (globalThis as any).cosense
+)();

--- a/vendor/events.ts
+++ b/vendor/events.ts
@@ -23,7 +23,7 @@ export interface Abortable {
  * For `EventTarget`s this is the only way to get the event listeners for the
  * event target. This is useful for debugging and diagnostic purposes.
  *
- * ```js
+ * ```js ignore
  * const { getEventListeners, EventEmitter } = require('events');
  *
  * {
@@ -48,7 +48,7 @@ export declare function getEventListeners(
 ): Function[];
 
 /**
- * ```js
+ * ```js ignore
  * const { on, EventEmitter } = require('events');
  *
  * (async () => {
@@ -77,7 +77,7 @@ export declare function getEventListeners(
  *
  * An `AbortSignal` can be used to cancel waiting on events:
  *
- * ```js
+ * ```js ignore
  * const { on, EventEmitter } = require('events');
  * const ac = new AbortController();
  *
@@ -120,7 +120,7 @@ export declare function on(
  * This method is intentionally generic and works with the web platform [EventTarget](https://dom.spec.whatwg.org/#interface-eventtarget) interface, which has no special`'error'` event
  * semantics and does not listen to the `'error'` event.
  *
- * ```js
+ * ```js ignore
  * const { once, EventEmitter } = require('events');
  *
  * async function run() {
@@ -152,7 +152,7 @@ export declare function on(
  * '`error'` event itself, then it is treated as any other kind of event without
  * special handling:
  *
- * ```js
+ * ```js ignore
  * const { EventEmitter, once } = require('events');
  *
  * const ee = new EventEmitter();
@@ -168,7 +168,7 @@ export declare function on(
  *
  * An `AbortSignal` can be used to cancel waiting for the event:
  *
- * ```js
+ * ```js ignore
  * const { EventEmitter, once } = require('events');
  *
  * const ee = new EventEmitter();
@@ -228,7 +228,7 @@ interface StaticEventEmitterOptions {
 /**
  * The `EventEmitter` class is defined and exposed by the `events` module:
  *
- * ```js
+ * ```js ignore
  * const EventEmitter = require('events');
  * ```
  *
@@ -253,7 +253,7 @@ export declare class EventEmitter {
    * already been added. Multiple calls passing the same combination of `eventName`and `listener` will result in the `listener` being added, and called, multiple
    * times.
    *
-   * ```js
+   * ```js ignore
    * server.on('connection', (stream) => {
    *   console.log('someone connected!');
    * });
@@ -264,7 +264,7 @@ export declare class EventEmitter {
    * By default, event listeners are invoked in the order they are added. The`emitter.prependListener()` method can be used as an alternative to add the
    * event listener to the beginning of the listeners array.
    *
-   * ```js
+   * ```js ignore
    * const myEE = new EventEmitter();
    * myEE.on('foo', () => console.log('a'));
    * myEE.prependListener('foo', () => console.log('b'));
@@ -282,7 +282,7 @@ export declare class EventEmitter {
    * Adds a **one-time**`listener` function for the event named `eventName`. The
    * next time `eventName` is triggered, this listener is removed and then invoked.
    *
-   * ```js
+   * ```js ignore
    * server.once('connection', (stream) => {
    *   console.log('Ah, we have our first user!');
    * });
@@ -293,7 +293,7 @@ export declare class EventEmitter {
    * By default, event listeners are invoked in the order they are added. The`emitter.prependOnceListener()` method can be used as an alternative to add the
    * event listener to the beginning of the listeners array.
    *
-   * ```js
+   * ```js ignore
    * const myEE = new EventEmitter();
    * myEE.once('foo', () => console.log('a'));
    * myEE.prependOnceListener('foo', () => console.log('b'));
@@ -310,7 +310,7 @@ export declare class EventEmitter {
   /**
    * Removes the specified `listener` from the listener array for the event named`eventName`.
    *
-   * ```js
+   * ```js ignore
    * const callback = (stream) => {
    *   console.log('someone connected!');
    * };
@@ -328,7 +328,7 @@ export declare class EventEmitter {
    * time of emitting are called in order. This implies that any`removeListener()` or `removeAllListeners()` calls _after_ emitting and_before_ the last listener finishes execution will
    * not remove them from`emit()` in progress. Subsequent events behave as expected.
    *
-   * ```js
+   * ```js ignore
    * const myEmitter = new MyEmitter();
    *
    * const callbackA = () => {
@@ -368,7 +368,7 @@ export declare class EventEmitter {
    * event (as in the example below), `removeListener()` will remove the most
    * recently added instance. In the example the `once('ping')`listener is removed:
    *
-   * ```js
+   * ```js ignore
    * const ee = new EventEmitter();
    *
    * function pong() {
@@ -425,7 +425,7 @@ export declare class EventEmitter {
   /**
    * Returns a copy of the array of listeners for the event named `eventName`.
    *
-   * ```js
+   * ```js ignore
    * server.on('connection', (stream) => {
    *   console.log('someone connected!');
    * });
@@ -440,7 +440,7 @@ export declare class EventEmitter {
    * Returns a copy of the array of listeners for the event named `eventName`,
    * including any wrappers (such as those created by `.once()`).
    *
-   * ```js
+   * ```js ignore
    * const emitter = new EventEmitter();
    * emitter.once('log', () => console.log('log once'));
    *
@@ -473,7 +473,7 @@ export declare class EventEmitter {
    *
    * Returns `true` if the event had listeners, `false` otherwise.
    *
-   * ```js
+   * ```js ignore
    * const EventEmitter = require('events');
    * const myEmitter = new EventEmitter();
    *
@@ -520,7 +520,7 @@ export declare class EventEmitter {
    * already been added. Multiple calls passing the same combination of `eventName`and `listener` will result in the `listener` being added, and called, multiple
    * times.
    *
-   * ```js
+   * ```js ignore
    * server.prependListener('connection', (stream) => {
    *   console.log('someone connected!');
    * });
@@ -539,7 +539,7 @@ export declare class EventEmitter {
    * Adds a **one-time**`listener` function for the event named `eventName` to the_beginning_ of the listeners array. The next time `eventName` is triggered, this
    * listener is removed, and then invoked.
    *
-   * ```js
+   * ```js ignore
    * server.prependOnceListener('connection', (stream) => {
    *   console.log('Ah, we have our first user!');
    * });
@@ -558,7 +558,7 @@ export declare class EventEmitter {
    * Returns an array listing the events for which the emitter has registered
    * listeners. The values in the array are strings or `Symbol`s.
    *
-   * ```js
+   * ```js ignore
    * const EventEmitter = require('events');
    * const myEE = new EventEmitter();
    * myEE.on('foo', () => {});
@@ -584,7 +584,7 @@ export declare class EventEmitter {
    * This method is intentionally generic and works with the web platform [EventTarget](https://dom.spec.whatwg.org/#interface-eventtarget) interface, which has no special`'error'` event
    * semantics and does not listen to the `'error'` event.
    *
-   * ```js
+   * ```js ignore
    * const { once, EventEmitter } = require('events');
    *
    * async function run() {
@@ -616,7 +616,7 @@ export declare class EventEmitter {
    * '`error'` event itself, then it is treated as any other kind of event without
    * special handling:
    *
-   * ```js
+   * ```js ignore
    * const { EventEmitter, once } = require('events');
    *
    * const ee = new EventEmitter();
@@ -632,7 +632,7 @@ export declare class EventEmitter {
    *
    * An `AbortSignal` can be used to cancel waiting for the event:
    *
-   * ```js
+   * ```js ignore
    * const { EventEmitter, once } = require('events');
    *
    * const ee = new EventEmitter();
@@ -668,7 +668,7 @@ export declare class EventEmitter {
     options?: StaticEventEmitterOptions,
   ): Promise<any[]>;
   /**
-   * ```js
+   * ```js ignore
    * const { on, EventEmitter } = require('events');
    *
    * (async () => {
@@ -697,7 +697,7 @@ export declare class EventEmitter {
    *
    * An `AbortSignal` can be used to cancel waiting on events:
    *
-   * ```js
+   * ```js ignore
    * const { on, EventEmitter } = require('events');
    * const ac = new AbortController();
    *
@@ -729,7 +729,7 @@ export declare class EventEmitter {
   /**
    * A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
    *
-   * ```js
+   * ```js ignore
    * const { EventEmitter, listenerCount } = require('events');
    * const myEmitter = new EventEmitter();
    * myEmitter.on('event', () => {});
@@ -756,7 +756,7 @@ export declare class EventEmitter {
    * For `EventTarget`s this is the only way to get the event listeners for the
    * event target. This is useful for debugging and diagnostic purposes.
    *
-   * ```js
+   * ```js ignore
    * const { getEventListeners, EventEmitter } = require('events');
    *
    * {


### PR DESCRIPTION
Users no longer write `declare const scrapbox: Scrapbox;` in each file.