### PR TITLE
fix(api): `PageSummery` does not has `commitId`

### DIFF
--- a/api/pages/project.ts
+++ b/api/pages/project.ts
@@ -23,9 +23,6 @@ export interface PageSummery {
   /** page id */
   id: PageId;
 
-  /** 最新の編集コミットid */
-  commitId: CommitId;
-
   /** the title of a page */
   title: string;
 


### PR DESCRIPTION
fix https://github.com/scrapbox-jp/types/pull/73